### PR TITLE
Add “Urf” exclusions for classes that ends with “Request”.

### DIFF
--- a/Android/findbugs/findbugs-exclusions.xml
+++ b/Android/findbugs/findbugs-exclusions.xml
@@ -19,6 +19,11 @@
         <Class name="~.*\.MediaItem" />
     </Match>
 
+    <!-- Ignore unsued fields for classes that ends with 'Request' -->
+    <Match>
+        <Class name="~.*Request" />
+        <Bug code="UrF" />
+    </Match>
     <!-- Ignore JUnit test classes - other than JUnit issues -->
     <Match>
         <Class name="~.*\.*Test" />


### PR DESCRIPTION
This exclusion add because we have POJO classes that used only for sending them to server side. And it means that for such classes we don’t need getters.